### PR TITLE
bump GradleRIO version to 2022.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
 
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2022.2.1"
+    id "edu.wpi.first.GradleRIO" version "2022.3.1"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
For use with the v4 RIO firmware
https://github.com/wpilibsuite/allwpilib/releases/tag/v2022.3.1