### PR TITLE
feat: add TestAllMotorsCommand

### DIFF
--- a/src/main/java/org/team1540/robot2022/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2022/RobotContainer.java
@@ -69,7 +69,7 @@ public class RobotContainer {
     public final FFTankDriveCommand ffTankDriveCommand = new FFTankDriveCommand(drivetrain, driverController);
 
     // Unsure what buttons to assign to this, currently uses triggers when called.
-    public final TestAllMotorsCommand testAllMotorsCommand = new TestAllMotorsCommand(driverController);
+    public final TestAllMotorsCommand testAllMotorsCommand = new TestAllMotorsCommand(drivetrain, intake, indexer, shooter, driverController);
 
     // Misc
     private final SendableChooser<Command> autoChooser = new SendableChooser<>();

--- a/src/main/java/org/team1540/robot2022/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2022/RobotContainer.java
@@ -68,6 +68,9 @@ public class RobotContainer {
     // coop:button(RTrigger,Reverse,pilot)
     public final FFTankDriveCommand ffTankDriveCommand = new FFTankDriveCommand(drivetrain, driverController);
 
+    // Unsure what buttons to assign to this, currently uses triggers when called.
+    public final TestAllMotorsCommand testAllMotorsCommand = new TestAllMotorsCommand(driverController);
+
     // Misc
     private final SendableChooser<Command> autoChooser = new SendableChooser<>();
 

--- a/src/main/java/org/team1540/robot2022/commands/drivetrain/Drivetrain.java
+++ b/src/main/java/org/team1540/robot2022/commands/drivetrain/Drivetrain.java
@@ -18,10 +18,10 @@ import org.team1540.robot2022.utils.ChickenTalonFX;
 import org.team1540.robot2022.utils.NavX;
 
 public class Drivetrain extends SubsystemBase {
-    private final ChickenTalonFX driveLFront = new ChickenTalonFX(Motors.LEFT_FRONT);
-    private final ChickenTalonFX driveLRear = new ChickenTalonFX(Motors.LEFT_REAR);
-    private final ChickenTalonFX driveRFront = new ChickenTalonFX(Motors.RIGHT_FRONT);
-    private final ChickenTalonFX driveRRear = new ChickenTalonFX(Motors.RIGHT_REAR);
+    public final ChickenTalonFX driveLFront = new ChickenTalonFX(Motors.LEFT_FRONT);
+    public final ChickenTalonFX driveLRear = new ChickenTalonFX(Motors.LEFT_REAR);
+    public final ChickenTalonFX driveRFront = new ChickenTalonFX(Motors.RIGHT_FRONT);
+    public final ChickenTalonFX driveRRear = new ChickenTalonFX(Motors.RIGHT_REAR);
     private final ChickenTalonFX[] driveL = {driveLFront, driveLRear};
     private final ChickenTalonFX[] driveR = {driveRFront, driveRRear};
     private final ChickenTalonFX[] driveMotors = {driveLFront, driveLRear, driveRFront, driveRRear};

--- a/src/main/java/org/team1540/robot2022/commands/indexer/Indexer.java
+++ b/src/main/java/org/team1540/robot2022/commands/indexer/Indexer.java
@@ -14,8 +14,8 @@ import org.team1540.robot2022.Constants.IndexerConstants.IndexerMotors;
 import org.team1540.robot2022.utils.ChickenTalonFX;
 
 public class Indexer extends SubsystemBase {
-    private final ChickenTalonFX bottomMotor = new ChickenTalonFX(IndexerMotors.BOTTOM_MOTOR);
-    private final ChickenTalonFX topMotor = new ChickenTalonFX(IndexerMotors.TOP_MOTOR);
+    public final ChickenTalonFX bottomMotor = new ChickenTalonFX(IndexerMotors.BOTTOM_MOTOR);
+    public final ChickenTalonFX topMotor = new ChickenTalonFX(IndexerMotors.TOP_MOTOR);
     private final ChickenTalonFX[] motors = {topMotor, bottomMotor};
 
     private final DigitalInput topSensor = new DigitalInput(BeamBreaks.TOP_INDEXER_SENSOR);

--- a/src/main/java/org/team1540/robot2022/commands/intake/Intake.java
+++ b/src/main/java/org/team1540/robot2022/commands/intake/Intake.java
@@ -12,7 +12,7 @@ import org.team1540.robot2022.utils.ChickenTalonFX;
 
 public class Intake extends SubsystemBase {
     private final Solenoid solenoid = new Solenoid(Constants.PNEUMATIC_HUB, PneumaticsModuleType.REVPH, Constants.IntakeConstants.SOLENOID);
-    private final ChickenTalonFX motor = new ChickenTalonFX(Constants.IntakeConstants.FALCON);
+    public final ChickenTalonFX motor = new ChickenTalonFX(Constants.IntakeConstants.FALCON);
 
     public Intake() {
         Constants.IntakeConstants.CURRENT_LIMIT_CONFIG.applyTo(motor);

--- a/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
+++ b/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
@@ -1,6 +1,9 @@
 package org.team1540.robot2022.utils;
 
-import org.team1540.robot2022.Constants;
+import org.team1540.robot2022.commands.drivetrain.Drivetrain;
+import org.team1540.robot2022.commands.indexer.Indexer;
+import org.team1540.robot2022.commands.intake.Intake;
+import org.team1540.robot2022.commands.shooter.Shooter;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;

--- a/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
+++ b/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
@@ -17,10 +17,7 @@ public class TestAllMotorsCommand extends CommandBase {
     public TestAllMotorsCommand(Drivetrain drivetrain, Intake intake, Indexer indexer, Shooter shooter, XboxController controller) {
         this.controller = controller;
 
-        addRequirements(drivetrain);
-        addRequirements(intake);
-        addRequirements(indexer);
-        addRequirements(shooter);
+        addRequirements(drivetrain, intake, indexer, shooter);
 
         motorChooser.setDefaultOption("Drive: Left Front", drivetrain.driveLFront);
         motorChooser.addOption("Drive: Left Rear", drivetrain.driveLRear);
@@ -36,8 +33,7 @@ public class TestAllMotorsCommand extends CommandBase {
     }
 
     public void execute() {
-        double percentOutput = MathUtils.deadzone(controller.getLeftTriggerAxis(), 0.15);
-        percentOutput -= MathUtils.deadzone(controller.getRightTriggerAxis(), 0.15);
+        double percentOutput = MathUtils.deadzone(controller.getLeftTriggerAxis(), 0.15) - MathUtils.deadzone(controller.getRightTriggerAxis(), 0.15);
         motorChooser.getSelected().setPercent(percentOutput);
     }
 

--- a/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
+++ b/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
@@ -1,0 +1,57 @@
+package org.team1540.robot2022.utils;
+
+import org.team1540.robot2022.Constants;
+
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class TestAllMotorsCommand extends CommandBase {
+    private XboxController controller;
+
+    private final ChickenTalonFX[] allTalonFXs = new ChickenTalonFX[]{
+        new ChickenTalonFX(Constants.DriveConstants.Motors.LEFT_FRONT),
+        new ChickenTalonFX(Constants.DriveConstants.Motors.LEFT_REAR),
+        new ChickenTalonFX(Constants.DriveConstants.Motors.RIGHT_FRONT),
+        new ChickenTalonFX(Constants.DriveConstants.Motors.RIGHT_REAR),
+        new ChickenTalonFX(Constants.IntakeConstants.FALCON),
+        new ChickenTalonFX(Constants.ShooterConstants.FRONT),
+        new ChickenTalonFX(Constants.ShooterConstants.REAR),
+        new ChickenTalonFX(Constants.IndexerConstants.IndexerMotors.TOP_MOTOR),
+        new ChickenTalonFX(Constants.IndexerConstants.IndexerMotors.BOTTOM_MOTOR),
+    };
+
+    private final SendableChooser<Integer> motorChooser = new SendableChooser<>();
+
+    public TestAllMotorsCommand(XboxController controller) {
+        this.controller = controller;
+
+        motorChooser.setDefaultOption("Drive: Left Front", 0);
+        motorChooser.addOption("Drive: Left Rear", 1);
+        motorChooser.addOption("Drive: Right Front", 2);
+        motorChooser.addOption("Drive: Right Rear", 3);
+        motorChooser.addOption("Intake: Main", 4);
+        motorChooser.addOption("Shooter: Front", 5);
+        motorChooser.addOption("Shooter: Rear", 6);
+        motorChooser.addOption("Indexer: Top", 7);
+        motorChooser.addOption("Indexer: bottom", 8);
+
+        SmartDashboard.putData(motorChooser);
+    }
+
+    public void execute() {
+        double percentOutput = MathUtils.deadzone(controller.getLeftTriggerAxis(), 0.15);
+        percentOutput -= MathUtils.deadzone(controller.getRightTriggerAxis(), 0.15);
+        if (percentOutput < -1) {
+            percentOutput = -1;
+        } else if (percentOutput > 1) {
+            percentOutput = 1;
+        }
+        allTalonFXs[motorChooser.getSelected()].setPercent(percentOutput);
+    }
+
+    public void end(boolean isInterrupted) {
+        allTalonFXs[motorChooser.getSelected()].setPercent(0);
+    } 
+}

--- a/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
+++ b/src/main/java/org/team1540/robot2022/utils/TestAllMotorsCommand.java
@@ -9,33 +9,25 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 
 public class TestAllMotorsCommand extends CommandBase {
     private XboxController controller;
+    private final SendableChooser<ChickenTalonFX> motorChooser = new SendableChooser<>();
 
-    private final ChickenTalonFX[] allTalonFXs = new ChickenTalonFX[]{
-        new ChickenTalonFX(Constants.DriveConstants.Motors.LEFT_FRONT),
-        new ChickenTalonFX(Constants.DriveConstants.Motors.LEFT_REAR),
-        new ChickenTalonFX(Constants.DriveConstants.Motors.RIGHT_FRONT),
-        new ChickenTalonFX(Constants.DriveConstants.Motors.RIGHT_REAR),
-        new ChickenTalonFX(Constants.IntakeConstants.FALCON),
-        new ChickenTalonFX(Constants.ShooterConstants.FRONT),
-        new ChickenTalonFX(Constants.ShooterConstants.REAR),
-        new ChickenTalonFX(Constants.IndexerConstants.IndexerMotors.TOP_MOTOR),
-        new ChickenTalonFX(Constants.IndexerConstants.IndexerMotors.BOTTOM_MOTOR),
-    };
-
-    private final SendableChooser<Integer> motorChooser = new SendableChooser<>();
-
-    public TestAllMotorsCommand(XboxController controller) {
+    public TestAllMotorsCommand(Drivetrain drivetrain, Intake intake, Indexer indexer, Shooter shooter, XboxController controller) {
         this.controller = controller;
 
-        motorChooser.setDefaultOption("Drive: Left Front", 0);
-        motorChooser.addOption("Drive: Left Rear", 1);
-        motorChooser.addOption("Drive: Right Front", 2);
-        motorChooser.addOption("Drive: Right Rear", 3);
-        motorChooser.addOption("Intake: Main", 4);
-        motorChooser.addOption("Shooter: Front", 5);
-        motorChooser.addOption("Shooter: Rear", 6);
-        motorChooser.addOption("Indexer: Top", 7);
-        motorChooser.addOption("Indexer: bottom", 8);
+        addRequirements(drivetrain);
+        addRequirements(intake);
+        addRequirements(indexer);
+        addRequirements(shooter);
+
+        motorChooser.setDefaultOption("Drive: Left Front", drivetrain.driveLFront);
+        motorChooser.addOption("Drive: Left Rear", drivetrain.driveLRear);
+        motorChooser.addOption("Drive: Right Front", drivetrain.driveRFront);
+        motorChooser.addOption("Drive: Right Rear", drivetrain.driveRRear);
+        motorChooser.addOption("Intake: Main", intake.motor);
+        motorChooser.addOption("Shooter: Front", shooter.shooterMotorFront);
+        motorChooser.addOption("Shooter: Rear", shooter.shooterMotorRear);
+        motorChooser.addOption("Indexer: Top", indexer.topMotor);
+        motorChooser.addOption("Indexer: bottom", indexer.bottomMotor);
 
         SmartDashboard.putData(motorChooser);
     }
@@ -43,15 +35,10 @@ public class TestAllMotorsCommand extends CommandBase {
     public void execute() {
         double percentOutput = MathUtils.deadzone(controller.getLeftTriggerAxis(), 0.15);
         percentOutput -= MathUtils.deadzone(controller.getRightTriggerAxis(), 0.15);
-        if (percentOutput < -1) {
-            percentOutput = -1;
-        } else if (percentOutput > 1) {
-            percentOutput = 1;
-        }
-        allTalonFXs[motorChooser.getSelected()].setPercent(percentOutput);
+        motorChooser.getSelected().setPercent(percentOutput);
     }
 
     public void end(boolean isInterrupted) {
-        allTalonFXs[motorChooser.getSelected()].setPercent(0);
+        motorChooser.getSelected().setPercent(0);
     } 
 }


### PR DESCRIPTION
Creates the command, with a chooser in SmartDashboard to select what motor.
This does left/right triggers for forward/reverse, but I can't figure out how to override drivetrain so that it doesn't call that as well.
I think if you just don't set a default command at all it might actually work, but didn't get to testing that yesterday.